### PR TITLE
feat: Add conversational memory tool

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+class JsonFileMemory:
+    def __init__(self, file_path: Path):
+        self.file_path = file_path
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.file_path.exists():
+            self.file_path.write_text("[]")
+
+    def read(self) -> List[Dict[str, Any]]:
+        return json.loads(self.file_path.read_text())
+
+    def append(self, entry: Dict[str, Any]):
+        content = self.read()
+        content.append(entry)
+        self.file_path.write_text(json.dumps(content, indent=2))

--- a/models.py
+++ b/models.py
@@ -11,7 +11,7 @@ class InputField(BaseModel):
     help: Optional[str] = None
 
 class ToolRef(BaseModel):
-    name: Literal["math_eval","string_template","kv_memory","http_get", "web_search"]
+    name: Literal["math_eval","string_template","kv_memory","http_get", "web_search", "conversational_memory"]
     params: Dict[str, Any] = Field(default_factory=dict)
 
 class RunLimits(BaseModel):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -67,7 +67,7 @@ with tabs[0]:
             row["default"] = st.text_input("default (string or JSON)", key=f"default_{i}", value="" if row.get("default") in [None,"None"] else str(row.get("default")))
 
     st.subheader("Tools")
-    tool_names = ["math_eval","string_template","kv_memory","http_get", "web_search"]
+    tool_names = ["math_eval","string_template","kv_memory","http_get", "web_search", "conversational_memory"]
     selected_tools = st.multiselect("Enable tools", tool_names, default=[])
     tools = [ToolRef(name=t) for t in selected_tools]
 
@@ -235,7 +235,7 @@ with tabs[2]:
             input_file.write_text(json.dumps(values, indent=2), encoding="utf-8")
             
             # Build the command
-            cmd = ["python", "sandbox_executor.py", "run", "--agent", str(agent_spec_path), "--input_path", str(input_file), "--out", str(run_dir)]
+            cmd = ["python", "sandbox_executor.py", "run", "--agent", str(agent_spec_path), "--input_path", str(input_file), "--out", str(run_dir), "--run_id", run_id]
             
             # Show command in debug mode
             if debug_mode != "Off":


### PR DESCRIPTION
This commit introduces a new `conversational_memory` tool that allows agents to maintain state across interactions within a single run.

- A `JsonFileMemory` class is added to handle reading from and writing to a JSON file.
- The `conversational_memory` tool uses this class to provide `read` and `append` operations on the conversation history.
- The `sandbox_executor.py` script is updated to pass a unique `run_id` to the tool, ensuring that memory is sandboxed per agent run.
- The Streamlit UI is updated to include the new tool in the selection list and to pass the `run_id` when executing an agent.